### PR TITLE
Add obsidian minimal theme

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,4 +17,5 @@
   obsidian-tasks = pkgs.callPackage ./pkgs/obsidian-tasks { };
   obsidian-everforest-enchanted =
     pkgs.callPackage ./pkgs/obsidian-everforest-enchanted { };
+  obsidian-minimal = pkgs.callPackage ./pkgs/obsidian-minimal { };
 }

--- a/pkgs/obsidian-minimal/default.nix
+++ b/pkgs/obsidian-minimal/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    cp -r $src/* $out/
+    cp $src/theme.css $out/
+    cp $src/manifest.json $out/
+    ln -s $out/theme.css $out/obsidian.css
   '';
 
   meta = with lib; {

--- a/pkgs/obsidian-minimal/default.nix
+++ b/pkgs/obsidian-minimal/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "obsidian-minimal";
+  version = "8.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kepano";
+    repo = "obsidian-minimal";
+    rev = version;
+    sha256 = "1x7whw27abqx83hc2dn1kphc7r76vbn7hrn4i0f41vrjsc6jjfn3";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r $src/* $out/
+  '';
+
+  meta = with lib; {
+    description = "Minimal theme for Obsidian";
+    homepage = "https://github.com/kepano/obsidian-minimal";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package `obsidian-minimal` theme from kepano/obsidian-minimal
- expose the theme via `default.nix`

## Testing
- `nix --extra-experimental-features 'nix-command flakes' build .#obsidian-minimal`
- `nix --extra-experimental-features 'nix-command flakes' build .#obsidian-tasks`
- `nix --extra-experimental-features 'nix-command flakes' flake check`


------
https://chatgpt.com/codex/tasks/task_e_6844a0cf1f1c832aa08a5f4cf8eca621